### PR TITLE
M29: Enable multi-worker DataLoader (num_workers=4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ outputs/
 
 # W&B
 wandb/
+checkpoints/

--- a/configs/training/default.yaml
+++ b/configs/training/default.yaml
@@ -6,4 +6,7 @@ batch_size: 32
 learning_rate: 0.001
 
 device: "cpu"
-num_workers: 0
+num_workers: 4
+pin_memory: true
+persistent_workers: true
+prefetch_factor: 2

--- a/src/coffee_leaf_classifier/train.py
+++ b/src/coffee_leaf_classifier/train.py
@@ -36,12 +36,34 @@ def train(cfg: DictConfig) -> None:
 
     batch_size = int(cfg.training.batch_size)
     num_workers = int(getattr(cfg.training, "num_workers", 0))
+    logger.info(f"Using DataLoader num_workers={num_workers}")
+
+    pin_memory = bool(getattr(cfg.training, "pin_memory", False))
+    persistent_workers = bool(getattr(cfg.training, "persistent_workers", False)) and num_workers > 0
+    prefetch_factor = int(getattr(cfg.training, "prefetch_factor", 2)) if num_workers > 0 else None
 
     train_ds = CoffeeLeafDataset("train")
     val_ds = CoffeeLeafDataset("validation")
 
-    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)
-    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=batch_size,
+        shuffle=True,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        persistent_workers=persistent_workers,
+        prefetch_factor=prefetch_factor,
+    )
+
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=batch_size,
+        shuffle=False,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+        persistent_workers=persistent_workers,
+        prefetch_factor=prefetch_factor,
+    )
 
     model = Model(
         num_classes=int(cfg.model.params.num_classes),


### PR DESCRIPTION
Enabling distributed data loading by configuring PyTorch DataLoader to use multiple worker processes during training.

Changes:
- Set num_workers: 4 as the default in configs/training/default.yaml
- Made data loading performance-related options configurable via Hydra:
   - pin_memory
   - persistent_workers
   - prefetch_factor
- Updated training code to safely apply these options to both training and validation DataLoaders
- Added a log message to make the number of DataLoader workers visible at runtime