### PR TITLE
configure DVC with no_scm for container use

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,5 @@
 [core]
     remote = gcs
+    no_scm = true
 ['remote "gcs"']
     url = gs://mlops-group-40-2026-dvc

--- a/dockerfiles/train.dockerfile
+++ b/dockerfiles/train.dockerfile
@@ -21,6 +21,5 @@ COPY data/coffee_leaf_diseases.dvc data/
 
 RUN uv sync --frozen
 
-# Pull data from GCS at runtime (needs GCP credentials available on Vertex AI)
-# Use --no-scm since container doesn't have git repo
-ENTRYPOINT ["sh", "-c", "uv run dvc pull --no-scm data/coffee_leaf_diseases.dvc && uv run src/coffee_leaf_classifier/train.py"]
+# Pull data from GCS at runtime (DVC config has no_scm=true for container use)
+ENTRYPOINT ["sh", "-c", "uv run dvc pull data/coffee_leaf_diseases.dvc && uv run src/coffee_leaf_classifier/train.py"]


### PR DESCRIPTION
The DVC pull was failing cause it needs a git repo 
added no_scm = true to config tells DVC to work without git