### PR TITLE
free disk space before docker build

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo docker image prune -af
+          df -h
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
No space left on device (os error 28)
Runner ran out of disk space

Now frees space before running.