### PR TITLE
W&B logging to correct team project with proper auth

### DIFF
--- a/.github/workflows/train-on-change.yaml
+++ b/.github/workflows/train-on-change.yaml
@@ -52,10 +52,16 @@ jobs:
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
-          # Create temp config with WANDB key injected
-          cat configs/vertex_train.yaml > /tmp/vertex_train.yaml
-          echo "      - name: WANDB_API_KEY" >> /tmp/vertex_train.yaml
-          echo "        value: \"${WANDB_API_KEY}\"" >> /tmp/vertex_train.yaml
+          # Inject WANDB_API_KEY into vertex config after GCS_MODEL_PATH entry
+          awk -v key="$WANDB_API_KEY" '
+            /value: gs:\/\/mlops-group-40-2026-dvc\/models\/model.ckpt/ {
+              print
+              print "      - name: WANDB_API_KEY"
+              print "        value: \"" key "\""
+              next
+            }
+            {print}
+          ' configs/vertex_train.yaml > /tmp/vertex_train.yaml
 
           gcloud ai custom-jobs create \
             --region=${{ env.REGION }} \

--- a/configs/experiment/default.yaml
+++ b/configs/experiment/default.yaml
@@ -15,6 +15,7 @@ logging:
   level: "INFO"
   wandb:
     enable: true
-    project: "coffee_leaf_classifier"
+    project: "coffee_leaf_diseases"
+    entity: "mlops-group-40"
     tags: ["baseline"]
     mode: "online"

--- a/src/coffee_leaf_classifier/train.py
+++ b/src/coffee_leaf_classifier/train.py
@@ -74,6 +74,7 @@ def train(cfg: DictConfig) -> None:
     if cfg.experiment.logging.enable and cfg.experiment.logging.wandb.enable:
         wandb_logger = WandbLogger(
             project=cfg.experiment.logging.wandb.project,
+            entity=cfg.experiment.logging.wandb.get("entity"),
             name=cfg.experiment.name,
             tags=list(cfg.experiment.logging.wandb.tags),
             offline=str(cfg.experiment.logging.wandb.mode).lower() == "offline",


### PR DESCRIPTION
Fixes W&B training runs not appearing in team dashboard

fixed project name
pass entity to wandb logger in train  
inject api key  into vertex AI config at runtime
